### PR TITLE
Fix do_build in lldp

### DIFF
--- a/scripts/external_libs/scapy-2.4.5/scapy/contrib/lldp.py
+++ b/scripts/external_libs/scapy-2.4.5/scapy/contrib/lldp.py
@@ -272,9 +272,9 @@ class LLDPDU(Packet):
         self._check()
         return super(LLDPDU, self).post_dissect(s)
 
-    def do_build(self):
+    def do_build(self, result):
         self._check()
-        return super(LLDPDU, self).do_build()
+        return super(LLDPDU, self).do_build(result)
 
 
 def _ldp_id_adjustlen(pkt, x):


### PR DESCRIPTION
Change `do_build` method implementation in lldp.py in order to be compatible with TRex scapy.